### PR TITLE
Fix APA bibliography web reference display

### DIFF
--- a/lib/shortcode/shortcode.request.php
+++ b/lib/shortcode/shortcode.request.php
@@ -513,6 +513,8 @@ function Zotpress_shortcode_request( $checkcache = false )
 						// REVIEW: Does this account for all citation styles?
 						/* chicago-author-date */ $item->bib = str_ireplace( htmlentities($item->data->url."."), "", $item->bib ); // Note the period
 						/* APA */ $item->bib = str_ireplace( htmlentities($item->data->url), "", $item->bib );
+                        // Fix APA citation by removing the last part of the "Retrieved from" text
+                        $item->bib = preg_replace('/(Retrieved \w+ \d+, \d+)(, from)/','${1}',$item->bib);
 						$item->bib = str_ireplace( " Retrieved from ", "", $item->bib );
 						$item->bib = str_ireplace( " Available from: ", "", $item->bib );
 


### PR DESCRIPTION
APA style appends "Retrieved {date}, from {url}" to references of type Web page when building a bibliography. When using the html wrap setting in Zotpress, this results in the string ", from" to dangle at the end of entries, which isn't pretty. This fix removes that dangling string.

Example

[The Killam Memorial Library](https://digitalexhibits.library.dal.ca/exhibits/show/lives-of-dal-volume-2/chapter-2-10/killam-memorial-library). (n.d.). Dalhousie Libraries Digital Exhibits. Retrieved April 9, 2023, from

becomes

[The Killam Memorial Library](https://digitalexhibits.library.dal.ca/exhibits/show/lives-of-dal-volume-2/chapter-2-10/killam-memorial-library). (n.d.). Dalhousie Libraries Digital Exhibits. Retrieved April 9, 2023