### PR TITLE
Support "preprint" for "itemtype" filter

### DIFF
--- a/lib/shortcode/shortcode.php
+++ b/lib/shortcode/shortcode.php
@@ -115,6 +115,7 @@ function Zotpress_func( $atts )
             'conferencePaper',
             'thesis',
             'report',
+	    'preprint',
             'encyclopediaArticle',
             'newspaperArticle',
             'magazineArticle',


### PR DESCRIPTION
see related support request: https://wordpress.org/support/topic/add-preprint-as-valid-itemtype/

this works when I use shortcode like:

```
[zotpress sortby="date" itemtype="preprint" order="desc"]
``` 