### PR TITLE
Fix widget for single account

### DIFF
--- a/lib/widget/widget.metabox.php
+++ b/lib/widget/widget.metabox.php
@@ -8,7 +8,7 @@
 
 		<?php
 
-		if ($wpdb->get_var("SELECT COUNT(*) FROM ".$wpdb->prefix."zotpress;") > 1)
+		if ($wpdb->get_var("SELECT COUNT(*) FROM ".$wpdb->prefix."zotpress;") >= 1)
 		{
 			// See if default exists
 			$zp_default_account = false;


### PR DESCRIPTION
Applying this fix https://wordpress.org/support/topic/error-on-gutenberg-but-not-dashboard/#post-18533675